### PR TITLE
Add checks for user registration

### DIFF
--- a/db/config.yaml
+++ b/db/config.yaml
@@ -4,4 +4,3 @@ actions:
   kind: synchronous
   handler_webhook_baseurl: http://localhost:3000
 # TODO: Create function for retrieving randomly ordered list of works from the database
-# TODO: Relax the fetched row count limits

--- a/db/config.yaml
+++ b/db/config.yaml
@@ -3,4 +3,3 @@ metadata_directory: metadata
 actions:
   kind: synchronous
   handler_webhook_baseurl: http://localhost:3000
-# TODO: Create function for retrieving randomly ordered list of works from the database

--- a/db/config.yaml
+++ b/db/config.yaml
@@ -3,3 +3,5 @@ metadata_directory: metadata
 actions:
   kind: synchronous
   handler_webhook_baseurl: http://localhost:3000
+# TODO: Create function for retrieving randomly ordered list of works from the database
+# TODO: Relax the fetched row count limits

--- a/db/metadata/databases/default/functions/functions.yaml
+++ b/db/metadata/databases/default/functions/functions.yaml
@@ -1,1 +1,2 @@
-[]
+- "!include public_list_characterizations.yaml"
+- "!include public_list_essays.yaml"

--- a/db/metadata/databases/default/functions/public_list_characterizations.yaml
+++ b/db/metadata/databases/default/functions/public_list_characterizations.yaml
@@ -1,0 +1,3 @@
+function:
+  name: list_characterizations
+  schema: public

--- a/db/metadata/databases/default/functions/public_list_essays.yaml
+++ b/db/metadata/databases/default/functions/public_list_essays.yaml
@@ -1,0 +1,3 @@
+function:
+  name: list_essays
+  schema: public

--- a/db/metadata/databases/default/tables/public_authors.yaml
+++ b/db/metadata/databases/default/tables/public_authors.yaml
@@ -2,37 +2,34 @@ table:
   name: authors
   schema: public
 array_relationships:
-- name: titles
-  using:
-    foreign_key_constraint_on:
-      column: author_id
-      table:
-        name: titles
-        schema: public
+  - name: titles
+    using:
+      foreign_key_constraint_on:
+        column: author_id
+        table:
+          name: titles
+          schema: public
 select_permissions:
-- permission:
-    columns:
-    - first_name
-    - last_name
-    - middle_name
-    filter: {}
-    limit: 50
-  role: anonymous
-- permission:
-    columns:
-    - first_name
-    - id
-    - last_name
-    - middle_name
-    filter: {}
-    limit: 50
-  role: student
-- permission:
-    columns:
-    - first_name
-    - id
-    - last_name
-    - middle_name
-    filter: {}
-    limit: 50
-  role: teacher
+  - permission:
+      columns:
+        - first_name
+        - last_name
+        - middle_name
+      filter: {}
+    role: anonymous
+  - permission:
+      columns:
+        - first_name
+        - id
+        - last_name
+        - middle_name
+      filter: {}
+    role: student
+  - permission:
+      columns:
+        - first_name
+        - id
+        - last_name
+        - middle_name
+      filter: {}
+    role: teacher

--- a/db/metadata/databases/default/tables/public_authors.yaml
+++ b/db/metadata/databases/default/tables/public_authors.yaml
@@ -2,34 +2,34 @@ table:
   name: authors
   schema: public
 array_relationships:
-  - name: titles
-    using:
-      foreign_key_constraint_on:
-        column: author_id
-        table:
-          name: titles
-          schema: public
+- name: titles
+  using:
+    foreign_key_constraint_on:
+      column: author_id
+      table:
+        name: titles
+        schema: public
 select_permissions:
-  - permission:
-      columns:
-        - first_name
-        - last_name
-        - middle_name
-      filter: {}
-    role: anonymous
-  - permission:
-      columns:
-        - first_name
-        - id
-        - last_name
-        - middle_name
-      filter: {}
-    role: student
-  - permission:
-      columns:
-        - first_name
-        - id
-        - last_name
-        - middle_name
-      filter: {}
-    role: teacher
+- permission:
+    columns:
+    - first_name
+    - last_name
+    - middle_name
+    filter: {}
+  role: anonymous
+- permission:
+    columns:
+    - first_name
+    - id
+    - last_name
+    - middle_name
+    filter: {}
+  role: student
+- permission:
+    columns:
+    - first_name
+    - id
+    - last_name
+    - middle_name
+    filter: {}
+  role: teacher

--- a/db/metadata/databases/default/tables/public_bookmarks.yaml
+++ b/db/metadata/databases/default/tables/public_bookmarks.yaml
@@ -2,64 +2,64 @@ table:
   name: bookmarks
   schema: public
 object_relationships:
-  - name: users_all
-    using:
-      foreign_key_constraint_on: user_id
-  - name: work
-    using:
-      foreign_key_constraint_on: work_id
+- name: users_all
+  using:
+    foreign_key_constraint_on: user_id
+- name: work
+  using:
+    foreign_key_constraint_on: work_id
 insert_permissions:
-  - permission:
-      backend_only: false
-      check:
-        user_id:
-          _eq: X-Hasura-User-Id
-      columns:
-        - name
-        - work_id
-      set:
-        user_id: x-hasura-User-Id
-    role: student
-  - permission:
-      backend_only: false
-      check:
-        user_id:
-          _eq: X-Hasura-User-Id
-      columns:
-        - name
-        - work_id
-      set:
-        user_id: x-hasura-User-Id
-    role: teacher
+- permission:
+    backend_only: false
+    check:
+      user_id:
+        _eq: X-Hasura-User-Id
+    columns:
+    - name
+    - work_id
+    set:
+      user_id: x-hasura-User-Id
+  role: student
+- permission:
+    backend_only: false
+    check:
+      user_id:
+        _eq: X-Hasura-User-Id
+    columns:
+    - name
+    - work_id
+    set:
+      user_id: x-hasura-User-Id
+  role: teacher
 select_permissions:
-  - permission:
-      allow_aggregations: true
-      columns:
-        - name
-        - work_id
-      filter:
-        user_id:
-          _eq: X-Hasura-User-Id
-      limit: 50
-    role: student
-  - permission:
-      allow_aggregations: true
-      columns:
-        - name
-        - work_id
-      filter:
-        user_id:
-          _eq: X-Hasura-User-Id
-      limit: 50
-    role: teacher
+- permission:
+    allow_aggregations: true
+    columns:
+    - name
+    - work_id
+    filter:
+      user_id:
+        _eq: X-Hasura-User-Id
+    limit: 50
+  role: student
+- permission:
+    allow_aggregations: true
+    columns:
+    - name
+    - work_id
+    filter:
+      user_id:
+        _eq: X-Hasura-User-Id
+    limit: 50
+  role: teacher
 delete_permissions:
-  - permission:
-      filter:
-        user_id:
-          _eq: X-Hasura-User-Id
-    role: student
-  - permission:
-      filter:
-        user_id:
-          _eq: X-Hasura-User-Id
-    role: teacher
+- permission:
+    filter:
+      user_id:
+        _eq: X-Hasura-User-Id
+  role: student
+- permission:
+    filter:
+      user_id:
+        _eq: X-Hasura-User-Id
+  role: teacher

--- a/db/metadata/databases/default/tables/public_bookmarks.yaml
+++ b/db/metadata/databases/default/tables/public_bookmarks.yaml
@@ -2,62 +2,64 @@ table:
   name: bookmarks
   schema: public
 object_relationships:
-- name: users_all
-  using:
-    foreign_key_constraint_on: user_id
-- name: work
-  using:
-    foreign_key_constraint_on: work_id
+  - name: users_all
+    using:
+      foreign_key_constraint_on: user_id
+  - name: work
+    using:
+      foreign_key_constraint_on: work_id
 insert_permissions:
-- permission:
-    backend_only: false
-    check:
-      user_id:
-        _eq: X-Hasura-User-Id
-    columns:
-    - name
-    - work_id
-    set:
-      user_id: x-hasura-User-Id
-  role: student
-- permission:
-    backend_only: false
-    check:
-      user_id:
-        _eq: X-Hasura-User-Id
-    columns:
-    - name
-    - work_id
-    set:
-      user_id: x-hasura-User-Id
-  role: teacher
+  - permission:
+      backend_only: false
+      check:
+        user_id:
+          _eq: X-Hasura-User-Id
+      columns:
+        - name
+        - work_id
+      set:
+        user_id: x-hasura-User-Id
+    role: student
+  - permission:
+      backend_only: false
+      check:
+        user_id:
+          _eq: X-Hasura-User-Id
+      columns:
+        - name
+        - work_id
+      set:
+        user_id: x-hasura-User-Id
+    role: teacher
 select_permissions:
-- permission:
-    allow_aggregations: true
-    columns:
-    - name
-    - work_id
-    filter:
-      user_id:
-        _eq: X-Hasura-User-Id
-  role: student
-- permission:
-    allow_aggregations: true
-    columns:
-    - name
-    - work_id
-    filter:
-      user_id:
-        _eq: X-Hasura-User-Id
-  role: teacher
+  - permission:
+      allow_aggregations: true
+      columns:
+        - name
+        - work_id
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
+      limit: 50
+    role: student
+  - permission:
+      allow_aggregations: true
+      columns:
+        - name
+        - work_id
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
+      limit: 50
+    role: teacher
 delete_permissions:
-- permission:
-    filter:
-      user_id:
-        _eq: X-Hasura-User-Id
-  role: student
-- permission:
-    filter:
-      user_id:
-        _eq: X-Hasura-User-Id
-  role: teacher
+  - permission:
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
+    role: student
+  - permission:
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
+    role: teacher

--- a/db/metadata/databases/default/tables/public_characterizations.yaml
+++ b/db/metadata/databases/default/tables/public_characterizations.yaml
@@ -2,46 +2,46 @@ table:
   name: characterizations
   schema: public
 object_relationships:
-- name: character
-  using:
-    foreign_key_constraint_on: character_id
-- name: work
-  using:
-    foreign_key_constraint_on: work_id
+  - name: character
+    using:
+      foreign_key_constraint_on: character_id
+  - name: work
+    using:
+      foreign_key_constraint_on: work_id
 insert_permissions:
-- permission:
-    backend_only: true
-    check:
-      work:
-        user_id:
-          _eq: X-Hasura-User-Id
-    columns:
-    - character_id
-    - work_id
-  role: student
-- permission:
-    backend_only: true
-    check:
-      work:
-        user_id:
-          _eq: X-Hasura-User-Id
-    columns:
-    - character_id
-    - work_id
-  role: teacher
+  - permission:
+      backend_only: true
+      check:
+        work:
+          user_id:
+            _eq: X-Hasura-User-Id
+      columns:
+        - character_id
+        - work_id
+    role: student
+  - permission:
+      backend_only: true
+      check:
+        work:
+          user_id:
+            _eq: X-Hasura-User-Id
+      columns:
+        - character_id
+        - work_id
+    role: teacher
 select_permissions:
-- permission:
-    columns: []
-    filter: {}
-    limit: 10
-  role: anonymous
-- permission:
-    columns: []
-    filter: {}
-    limit: 10
-  role: student
-- permission:
-    columns: []
-    filter: {}
-    limit: 10
-  role: teacher
+  - permission:
+      columns: []
+      filter: {}
+      limit: 50
+    role: anonymous
+  - permission:
+      columns: []
+      filter: {}
+      limit: 50
+    role: student
+  - permission:
+      columns: []
+      filter: {}
+      limit: 50
+    role: teacher

--- a/db/metadata/databases/default/tables/public_characterizations.yaml
+++ b/db/metadata/databases/default/tables/public_characterizations.yaml
@@ -2,46 +2,46 @@ table:
   name: characterizations
   schema: public
 object_relationships:
-  - name: character
-    using:
-      foreign_key_constraint_on: character_id
-  - name: work
-    using:
-      foreign_key_constraint_on: work_id
+- name: character
+  using:
+    foreign_key_constraint_on: character_id
+- name: work
+  using:
+    foreign_key_constraint_on: work_id
 insert_permissions:
-  - permission:
-      backend_only: true
-      check:
-        work:
-          user_id:
-            _eq: X-Hasura-User-Id
-      columns:
-        - character_id
-        - work_id
-    role: student
-  - permission:
-      backend_only: true
-      check:
-        work:
-          user_id:
-            _eq: X-Hasura-User-Id
-      columns:
-        - character_id
-        - work_id
-    role: teacher
+- permission:
+    backend_only: true
+    check:
+      work:
+        user_id:
+          _eq: X-Hasura-User-Id
+    columns:
+    - character_id
+    - work_id
+  role: student
+- permission:
+    backend_only: true
+    check:
+      work:
+        user_id:
+          _eq: X-Hasura-User-Id
+    columns:
+    - character_id
+    - work_id
+  role: teacher
 select_permissions:
-  - permission:
-      columns: []
-      filter: {}
-      limit: 50
-    role: anonymous
-  - permission:
-      columns: []
-      filter: {}
-      limit: 50
-    role: student
-  - permission:
-      columns: []
-      filter: {}
-      limit: 50
-    role: teacher
+- permission:
+    columns: []
+    filter: {}
+    limit: 50
+  role: anonymous
+- permission:
+    columns: []
+    filter: {}
+    limit: 50
+  role: student
+- permission:
+    columns: []
+    filter: {}
+    limit: 50
+  role: teacher

--- a/db/metadata/databases/default/tables/public_characters.yaml
+++ b/db/metadata/databases/default/tables/public_characters.yaml
@@ -2,34 +2,34 @@ table:
   name: characters
   schema: public
 object_relationships:
-  - name: title
-    using:
-      foreign_key_constraint_on: title_id
+- name: title
+  using:
+    foreign_key_constraint_on: title_id
 array_relationships:
-  - name: characterizations
-    using:
-      foreign_key_constraint_on:
-        column: character_id
-        table:
-          name: characterizations
-          schema: public
+- name: characterizations
+  using:
+    foreign_key_constraint_on:
+      column: character_id
+      table:
+        name: characterizations
+        schema: public
 select_permissions:
-  - permission:
-      columns:
-        - name
-      filter: {}
-    role: anonymous
-  - permission:
-      columns:
-        - id
-        - name
-        - title_id
-      filter: {}
-    role: student
-  - permission:
-      columns:
-        - id
-        - name
-        - title_id
-      filter: {}
-    role: teacher
+- permission:
+    columns:
+    - name
+    filter: {}
+  role: anonymous
+- permission:
+    columns:
+    - id
+    - name
+    - title_id
+    filter: {}
+  role: student
+- permission:
+    columns:
+    - id
+    - name
+    - title_id
+    filter: {}
+  role: teacher

--- a/db/metadata/databases/default/tables/public_characters.yaml
+++ b/db/metadata/databases/default/tables/public_characters.yaml
@@ -2,37 +2,34 @@ table:
   name: characters
   schema: public
 object_relationships:
-- name: title
-  using:
-    foreign_key_constraint_on: title_id
+  - name: title
+    using:
+      foreign_key_constraint_on: title_id
 array_relationships:
-- name: characterizations
-  using:
-    foreign_key_constraint_on:
-      column: character_id
-      table:
-        name: characterizations
-        schema: public
+  - name: characterizations
+    using:
+      foreign_key_constraint_on:
+        column: character_id
+        table:
+          name: characterizations
+          schema: public
 select_permissions:
-- permission:
-    columns:
-    - name
-    filter: {}
-    limit: 50
-  role: anonymous
-- permission:
-    columns:
-    - id
-    - name
-    - title_id
-    filter: {}
-    limit: 50
-  role: student
-- permission:
-    columns:
-    - id
-    - name
-    - title_id
-    filter: {}
-    limit: 50
-  role: teacher
+  - permission:
+      columns:
+        - name
+      filter: {}
+    role: anonymous
+  - permission:
+      columns:
+        - id
+        - name
+        - title_id
+      filter: {}
+    role: student
+  - permission:
+      columns:
+        - id
+        - name
+        - title_id
+      filter: {}
+    role: teacher

--- a/db/metadata/databases/default/tables/public_counties.yaml
+++ b/db/metadata/databases/default/tables/public_counties.yaml
@@ -2,29 +2,29 @@ table:
   name: counties
   schema: public
 array_relationships:
-  - name: schools
-    using:
-      foreign_key_constraint_on:
-        column: county_id
-        table:
-          name: schools
-          schema: public
+- name: schools
+  using:
+    foreign_key_constraint_on:
+      column: county_id
+      table:
+        name: schools
+        schema: public
 select_permissions:
-  - permission:
-      columns:
-        - id
-        - name
-      filter: {}
-    role: anonymous
-  - permission:
-      columns:
-        - id
-        - name
-      filter: {}
-    role: student
-  - permission:
-      columns:
-        - id
-        - name
-      filter: {}
-    role: teacher
+- permission:
+    columns:
+    - id
+    - name
+    filter: {}
+  role: anonymous
+- permission:
+    columns:
+    - id
+    - name
+    filter: {}
+  role: student
+- permission:
+    columns:
+    - id
+    - name
+    filter: {}
+  role: teacher

--- a/db/metadata/databases/default/tables/public_counties.yaml
+++ b/db/metadata/databases/default/tables/public_counties.yaml
@@ -2,32 +2,29 @@ table:
   name: counties
   schema: public
 array_relationships:
-- name: schools
-  using:
-    foreign_key_constraint_on:
-      column: county_id
-      table:
-        name: schools
-        schema: public
+  - name: schools
+    using:
+      foreign_key_constraint_on:
+        column: county_id
+        table:
+          name: schools
+          schema: public
 select_permissions:
-- permission:
-    columns:
-    - id
-    - name
-    filter: {}
-    limit: 50
-  role: anonymous
-- permission:
-    columns:
-    - id
-    - name
-    filter: {}
-    limit: 50
-  role: student
-- permission:
-    columns:
-    - id
-    - name
-    filter: {}
-    limit: 50
-  role: teacher
+  - permission:
+      columns:
+        - id
+        - name
+      filter: {}
+    role: anonymous
+  - permission:
+      columns:
+        - id
+        - name
+      filter: {}
+    role: student
+  - permission:
+      columns:
+        - id
+        - name
+      filter: {}
+    role: teacher

--- a/db/metadata/databases/default/tables/public_essays.yaml
+++ b/db/metadata/databases/default/tables/public_essays.yaml
@@ -2,52 +2,52 @@ table:
   name: essays
   schema: public
 object_relationships:
-- name: title
-  using:
-    foreign_key_constraint_on: title_id
-- name: work
-  using:
-    foreign_key_constraint_on: work_id
+  - name: title
+    using:
+      foreign_key_constraint_on: title_id
+  - name: work
+    using:
+      foreign_key_constraint_on: work_id
 insert_permissions:
-- permission:
-    backend_only: true
-    check:
-      work:
-        user_id:
-          _eq: X-Hasura-User-Id
-    columns:
-    - title_id
-    - work_id
-  role: student
-- permission:
-    backend_only: true
-    check:
-      work:
-        user_id:
-          _eq: X-Hasura-User-Id
-    columns:
-    - title_id
-    - work_id
-  role: teacher
-select_permissions:
-- permission:
-    columns: []
-    filter: {}
-    limit: 10
-  role: anonymous
-- permission:
-    columns: []
-    filter:
-      _or:
-      - work:
-          status:
-            _eq: approved
-      - work:
+  - permission:
+      backend_only: true
+      check:
+        work:
           user_id:
             _eq: X-Hasura-User-Id
-    limit: 10
-  role: student
-- permission:
-    columns: []
-    filter: {}
-  role: teacher
+      columns:
+        - title_id
+        - work_id
+    role: student
+  - permission:
+      backend_only: true
+      check:
+        work:
+          user_id:
+            _eq: X-Hasura-User-Id
+      columns:
+        - title_id
+        - work_id
+    role: teacher
+select_permissions:
+  - permission:
+      columns: []
+      filter: {}
+      limit: 50
+    role: anonymous
+  - permission:
+      columns: []
+      filter:
+        _or:
+          - work:
+              status:
+                _eq: approved
+          - work:
+              user_id:
+                _eq: X-Hasura-User-Id
+      limit: 50
+    role: student
+  - permission:
+      columns: []
+      filter: {}
+    role: teacher

--- a/db/metadata/databases/default/tables/public_essays.yaml
+++ b/db/metadata/databases/default/tables/public_essays.yaml
@@ -2,52 +2,52 @@ table:
   name: essays
   schema: public
 object_relationships:
-  - name: title
-    using:
-      foreign_key_constraint_on: title_id
-  - name: work
-    using:
-      foreign_key_constraint_on: work_id
+- name: title
+  using:
+    foreign_key_constraint_on: title_id
+- name: work
+  using:
+    foreign_key_constraint_on: work_id
 insert_permissions:
-  - permission:
-      backend_only: true
-      check:
-        work:
-          user_id:
-            _eq: X-Hasura-User-Id
-      columns:
-        - title_id
-        - work_id
-    role: student
-  - permission:
-      backend_only: true
-      check:
-        work:
-          user_id:
-            _eq: X-Hasura-User-Id
-      columns:
-        - title_id
-        - work_id
-    role: teacher
+- permission:
+    backend_only: true
+    check:
+      work:
+        user_id:
+          _eq: X-Hasura-User-Id
+    columns:
+    - title_id
+    - work_id
+  role: student
+- permission:
+    backend_only: true
+    check:
+      work:
+        user_id:
+          _eq: X-Hasura-User-Id
+    columns:
+    - title_id
+    - work_id
+  role: teacher
 select_permissions:
-  - permission:
-      columns: []
-      filter: {}
-      limit: 50
-    role: anonymous
-  - permission:
-      columns: []
-      filter:
-        _or:
-          - work:
-              status:
-                _eq: approved
-          - work:
-              user_id:
-                _eq: X-Hasura-User-Id
-      limit: 50
-    role: student
-  - permission:
-      columns: []
-      filter: {}
-    role: teacher
+- permission:
+    columns: []
+    filter: {}
+    limit: 50
+  role: anonymous
+- permission:
+    columns: []
+    filter:
+      _or:
+      - work:
+          status:
+            _eq: approved
+      - work:
+          user_id:
+            _eq: X-Hasura-User-Id
+    limit: 50
+  role: student
+- permission:
+    columns: []
+    filter: {}
+  role: teacher

--- a/db/metadata/databases/default/tables/public_students.yaml
+++ b/db/metadata/databases/default/tables/public_students.yaml
@@ -2,35 +2,35 @@ table:
   name: students
   schema: public
 object_relationships:
-  - name: users_all
-    using:
-      foreign_key_constraint_on: user_id
+- name: users_all
+  using:
+    foreign_key_constraint_on: user_id
 array_relationships:
-  - name: teacher_student_associations
-    using:
-      foreign_key_constraint_on:
-        column: student_id
-        table:
-          name: teacher_student_associations
-          schema: public
+- name: teacher_student_associations
+  using:
+    foreign_key_constraint_on:
+      column: student_id
+      table:
+        name: teacher_student_associations
+        schema: public
 select_permissions:
-  - permission:
-      columns: []
-      filter:
-        user_id:
-          _eq: X-Hasura-User-Id
-    role: student
-  - permission:
-      columns:
-        - user_id
-      filter: {}
-      limit: 50
-    role: teacher
+- permission:
+    columns: []
+    filter:
+      user_id:
+        _eq: X-Hasura-User-Id
+  role: student
+- permission:
+    columns:
+    - user_id
+    filter: {}
+    limit: 50
+  role: teacher
 update_permissions:
-  - permission:
-      check: null
-      columns: []
-      filter:
-        user_id:
-          _eq: X-Hasura-User-Id
-    role: student
+- permission:
+    check: null
+    columns: []
+    filter:
+      user_id:
+        _eq: X-Hasura-User-Id
+  role: student

--- a/db/metadata/databases/default/tables/public_students.yaml
+++ b/db/metadata/databases/default/tables/public_students.yaml
@@ -2,36 +2,35 @@ table:
   name: students
   schema: public
 object_relationships:
-- name: users_all
-  using:
-    foreign_key_constraint_on: user_id
+  - name: users_all
+    using:
+      foreign_key_constraint_on: user_id
 array_relationships:
-- name: teacher_student_associations
-  using:
-    foreign_key_constraint_on:
-      column: student_id
-      table:
-        name: teacher_student_associations
-        schema: public
+  - name: teacher_student_associations
+    using:
+      foreign_key_constraint_on:
+        column: student_id
+        table:
+          name: teacher_student_associations
+          schema: public
 select_permissions:
-- permission:
-    columns: []
-    filter:
-      user_id:
-        _eq: X-Hasura-User-Id
-    limit: 10
-  role: student
-- permission:
-    columns:
-    - user_id
-    filter: {}
-    limit: 30
-  role: teacher
+  - permission:
+      columns: []
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
+    role: student
+  - permission:
+      columns:
+        - user_id
+      filter: {}
+      limit: 50
+    role: teacher
 update_permissions:
-- permission:
-    check: null
-    columns: []
-    filter:
-      user_id:
-        _eq: X-Hasura-User-Id
-  role: student
+  - permission:
+      check: null
+      columns: []
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
+    role: student

--- a/db/metadata/databases/default/tables/public_teachers.yaml
+++ b/db/metadata/databases/default/tables/public_teachers.yaml
@@ -2,55 +2,55 @@ table:
   name: teachers
   schema: public
 object_relationships:
-- name: users_all
-  using:
-    foreign_key_constraint_on: user_id
+  - name: users_all
+    using:
+      foreign_key_constraint_on: user_id
 array_relationships:
-- name: teacher_student_associations
-  using:
-    foreign_key_constraint_on:
-      column: teacher_id
-      table:
-        name: teacher_student_associations
-        schema: public
-- name: works
-  using:
-    foreign_key_constraint_on:
-      column: teacher_id
-      table:
-        name: works
-        schema: public
+  - name: teacher_student_associations
+    using:
+      foreign_key_constraint_on:
+        column: teacher_id
+        table:
+          name: teacher_student_associations
+          schema: public
+  - name: works
+    using:
+      foreign_key_constraint_on:
+        column: teacher_id
+        table:
+          name: works
+          schema: public
 select_permissions:
-- permission:
-    columns:
-    - about
-    - image_url
-    filter: {}
-    limit: 10
-  role: anonymous
-- permission:
-    columns:
-    - about
-    - image_url
-    - user_id
-    filter: {}
-    limit: 10
-  role: student
-- permission:
-    columns:
-    - about
-    - image_url
-    - user_id
-    filter: {}
-    limit: 10
-  role: teacher
+  - permission:
+      columns:
+        - about
+        - image_url
+      filter: {}
+      limit: 50
+    role: anonymous
+  - permission:
+      columns:
+        - about
+        - image_url
+        - user_id
+      filter: {}
+      limit: 50
+    role: student
+  - permission:
+      columns:
+        - about
+        - image_url
+        - user_id
+      filter: {}
+      limit: 50
+    role: teacher
 update_permissions:
-- permission:
-    check: null
-    columns:
-    - about
-    - image_url
-    filter:
-      user_id:
-        _eq: X-Hasura-User-Id
-  role: teacher
+  - permission:
+      check: null
+      columns:
+        - about
+        - image_url
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
+    role: teacher

--- a/db/metadata/databases/default/tables/public_teachers.yaml
+++ b/db/metadata/databases/default/tables/public_teachers.yaml
@@ -2,55 +2,55 @@ table:
   name: teachers
   schema: public
 object_relationships:
-  - name: users_all
-    using:
-      foreign_key_constraint_on: user_id
+- name: users_all
+  using:
+    foreign_key_constraint_on: user_id
 array_relationships:
-  - name: teacher_student_associations
-    using:
-      foreign_key_constraint_on:
-        column: teacher_id
-        table:
-          name: teacher_student_associations
-          schema: public
-  - name: works
-    using:
-      foreign_key_constraint_on:
-        column: teacher_id
-        table:
-          name: works
-          schema: public
+- name: teacher_student_associations
+  using:
+    foreign_key_constraint_on:
+      column: teacher_id
+      table:
+        name: teacher_student_associations
+        schema: public
+- name: works
+  using:
+    foreign_key_constraint_on:
+      column: teacher_id
+      table:
+        name: works
+        schema: public
 select_permissions:
-  - permission:
-      columns:
-        - about
-        - image_url
-      filter: {}
-      limit: 50
-    role: anonymous
-  - permission:
-      columns:
-        - about
-        - image_url
-        - user_id
-      filter: {}
-      limit: 50
-    role: student
-  - permission:
-      columns:
-        - about
-        - image_url
-        - user_id
-      filter: {}
-      limit: 50
-    role: teacher
+- permission:
+    columns:
+    - about
+    - image_url
+    filter: {}
+    limit: 50
+  role: anonymous
+- permission:
+    columns:
+    - about
+    - image_url
+    - user_id
+    filter: {}
+    limit: 50
+  role: student
+- permission:
+    columns:
+    - about
+    - image_url
+    - user_id
+    filter: {}
+    limit: 50
+  role: teacher
 update_permissions:
-  - permission:
-      check: null
-      columns:
-        - about
-        - image_url
-      filter:
-        user_id:
-          _eq: X-Hasura-User-Id
-    role: teacher
+- permission:
+    check: null
+    columns:
+    - about
+    - image_url
+    filter:
+      user_id:
+        _eq: X-Hasura-User-Id
+  role: teacher

--- a/db/metadata/databases/default/tables/public_users.yaml
+++ b/db/metadata/databases/default/tables/public_users.yaml
@@ -2,154 +2,154 @@ table:
   name: users
   schema: public
 object_relationships:
-- name: school
-  using:
-    manual_configuration:
-      column_mapping:
-        school_id: id
-      insertion_order: null
-      remote_table:
-        name: schools
-        schema: public
-- name: student
-  using:
-    manual_configuration:
-      column_mapping:
-        id: user_id
-      insertion_order: null
-      remote_table:
-        name: students
-        schema: public
-- name: teacher
-  using:
-    manual_configuration:
-      column_mapping:
-        id: user_id
-      insertion_order: null
-      remote_table:
-        name: teachers
-        schema: public
-- name: teacher_request
-  using:
-    manual_configuration:
-      column_mapping:
-        id: user_id
-      insertion_order: null
-      remote_table:
-        name: teacher_requests
-        schema: public
+  - name: school
+    using:
+      manual_configuration:
+        column_mapping:
+          school_id: id
+        insertion_order: null
+        remote_table:
+          name: schools
+          schema: public
+  - name: student
+    using:
+      manual_configuration:
+        column_mapping:
+          id: user_id
+        insertion_order: null
+        remote_table:
+          name: students
+          schema: public
+  - name: teacher
+    using:
+      manual_configuration:
+        column_mapping:
+          id: user_id
+        insertion_order: null
+        remote_table:
+          name: teachers
+          schema: public
+  - name: teacher_request
+    using:
+      manual_configuration:
+        column_mapping:
+          id: user_id
+        insertion_order: null
+        remote_table:
+          name: teacher_requests
+          schema: public
 array_relationships:
-- name: bookmarks
-  using:
-    manual_configuration:
-      column_mapping:
-        id: user_id
-      insertion_order: null
-      remote_table:
-        name: bookmarks
-        schema: public
-- name: teacher_student_associations
-  using:
-    manual_configuration:
-      column_mapping:
-        id: initiator_id
-      insertion_order: null
-      remote_table:
-        name: teacher_student_associations
-        schema: public
-- name: works
-  using:
-    manual_configuration:
-      column_mapping:
-        id: user_id
-      insertion_order: null
-      remote_table:
-        name: works
-        schema: public
+  - name: bookmarks
+    using:
+      manual_configuration:
+        column_mapping:
+          id: user_id
+        insertion_order: null
+        remote_table:
+          name: bookmarks
+          schema: public
+  - name: teacher_student_associations
+    using:
+      manual_configuration:
+        column_mapping:
+          id: initiator_id
+        insertion_order: null
+        remote_table:
+          name: teacher_student_associations
+          schema: public
+  - name: works
+    using:
+      manual_configuration:
+        column_mapping:
+          id: user_id
+        insertion_order: null
+        remote_table:
+          name: works
+          schema: public
 select_permissions:
-- permission:
-    columns:
-    - created_at
-    - first_name
-    - last_name
-    - middle_name
-    - role
-    filter:
-      role:
-        _eq: teacher
-    limit: 10
-  role: anonymous
-- permission:
-    columns:
-    - created_at
-    - email
-    - first_name
-    - id
-    - last_name
-    - middle_name
-    - role
-    - school_id
-    - updated_at
-    filter:
-      _or:
-      - id:
-          _eq: X-Hasura-User-Id
-      - role:
+  - permission:
+      columns:
+        - created_at
+        - first_name
+        - last_name
+        - middle_name
+        - role
+      filter:
+        role:
           _eq: teacher
-    limit: 10
-  role: student
-- permission:
-    columns:
-    - created_at
-    - email
-    - first_name
-    - id
-    - last_name
-    - middle_name
-    - role
-    - school_id
-    - updated_at
-    filter:
-      _or:
-      - id:
-          _eq: X-Hasura-User-Id
-      - role:
-          _in:
-          - student
-          - teacher
-    limit: 10
-  role: teacher
+      limit: 50
+    role: anonymous
+  - permission:
+      columns:
+        - created_at
+        - email
+        - first_name
+        - id
+        - last_name
+        - middle_name
+        - role
+        - school_id
+        - updated_at
+      filter:
+        _or:
+          - id:
+              _eq: X-Hasura-User-Id
+          - role:
+              _eq: teacher
+      limit: 50
+    role: student
+  - permission:
+      columns:
+        - created_at
+        - email
+        - first_name
+        - id
+        - last_name
+        - middle_name
+        - role
+        - school_id
+        - updated_at
+      filter:
+        _or:
+          - id:
+              _eq: X-Hasura-User-Id
+          - role:
+              _in:
+                - student
+                - teacher
+      limit: 50
+    role: teacher
 update_permissions:
-- permission:
-    check: null
-    columns:
-    - first_name
-    - last_name
-    - middle_name
-    - school_id
-    filter:
-      id:
-        _eq: X-Hasura-User-Id
-  role: student
-- permission:
-    check: null
-    columns:
-    - first_name
-    - last_name
-    - middle_name
-    - school_id
-    filter:
-      id:
-        _eq: X-Hasura-User-Id
-  role: teacher
+  - permission:
+      check: null
+      columns:
+        - first_name
+        - last_name
+        - middle_name
+        - school_id
+      filter:
+        id:
+          _eq: X-Hasura-User-Id
+    role: student
+  - permission:
+      check: null
+      columns:
+        - first_name
+        - last_name
+        - middle_name
+        - school_id
+      filter:
+        id:
+          _eq: X-Hasura-User-Id
+    role: teacher
 delete_permissions:
-- permission:
-    filter:
-      id:
-        _eq: X-Hasura-User-Id
-  role: student
-- permission:
-    filter:
-      id:
-        _eq: X-Hasura-User-Id
-  role: teacher
+  - permission:
+      filter:
+        id:
+          _eq: X-Hasura-User-Id
+    role: student
+  - permission:
+      filter:
+        id:
+          _eq: X-Hasura-User-Id
+    role: teacher

--- a/db/metadata/databases/default/tables/public_users.yaml
+++ b/db/metadata/databases/default/tables/public_users.yaml
@@ -2,154 +2,154 @@ table:
   name: users
   schema: public
 object_relationships:
-  - name: school
-    using:
-      manual_configuration:
-        column_mapping:
-          school_id: id
-        insertion_order: null
-        remote_table:
-          name: schools
-          schema: public
-  - name: student
-    using:
-      manual_configuration:
-        column_mapping:
-          id: user_id
-        insertion_order: null
-        remote_table:
-          name: students
-          schema: public
-  - name: teacher
-    using:
-      manual_configuration:
-        column_mapping:
-          id: user_id
-        insertion_order: null
-        remote_table:
-          name: teachers
-          schema: public
-  - name: teacher_request
-    using:
-      manual_configuration:
-        column_mapping:
-          id: user_id
-        insertion_order: null
-        remote_table:
-          name: teacher_requests
-          schema: public
+- name: school
+  using:
+    manual_configuration:
+      column_mapping:
+        school_id: id
+      insertion_order: null
+      remote_table:
+        name: schools
+        schema: public
+- name: student
+  using:
+    manual_configuration:
+      column_mapping:
+        id: user_id
+      insertion_order: null
+      remote_table:
+        name: students
+        schema: public
+- name: teacher
+  using:
+    manual_configuration:
+      column_mapping:
+        id: user_id
+      insertion_order: null
+      remote_table:
+        name: teachers
+        schema: public
+- name: teacher_request
+  using:
+    manual_configuration:
+      column_mapping:
+        id: user_id
+      insertion_order: null
+      remote_table:
+        name: teacher_requests
+        schema: public
 array_relationships:
-  - name: bookmarks
-    using:
-      manual_configuration:
-        column_mapping:
-          id: user_id
-        insertion_order: null
-        remote_table:
-          name: bookmarks
-          schema: public
-  - name: teacher_student_associations
-    using:
-      manual_configuration:
-        column_mapping:
-          id: initiator_id
-        insertion_order: null
-        remote_table:
-          name: teacher_student_associations
-          schema: public
-  - name: works
-    using:
-      manual_configuration:
-        column_mapping:
-          id: user_id
-        insertion_order: null
-        remote_table:
-          name: works
-          schema: public
+- name: bookmarks
+  using:
+    manual_configuration:
+      column_mapping:
+        id: user_id
+      insertion_order: null
+      remote_table:
+        name: bookmarks
+        schema: public
+- name: teacher_student_associations
+  using:
+    manual_configuration:
+      column_mapping:
+        id: initiator_id
+      insertion_order: null
+      remote_table:
+        name: teacher_student_associations
+        schema: public
+- name: works
+  using:
+    manual_configuration:
+      column_mapping:
+        id: user_id
+      insertion_order: null
+      remote_table:
+        name: works
+        schema: public
 select_permissions:
-  - permission:
-      columns:
-        - created_at
-        - first_name
-        - last_name
-        - middle_name
-        - role
-      filter:
-        role:
+- permission:
+    columns:
+    - created_at
+    - first_name
+    - last_name
+    - middle_name
+    - role
+    filter:
+      role:
+        _eq: teacher
+    limit: 50
+  role: anonymous
+- permission:
+    columns:
+    - created_at
+    - email
+    - first_name
+    - id
+    - last_name
+    - middle_name
+    - role
+    - school_id
+    - updated_at
+    filter:
+      _or:
+      - id:
+          _eq: X-Hasura-User-Id
+      - role:
           _eq: teacher
-      limit: 50
-    role: anonymous
-  - permission:
-      columns:
-        - created_at
-        - email
-        - first_name
-        - id
-        - last_name
-        - middle_name
-        - role
-        - school_id
-        - updated_at
-      filter:
-        _or:
-          - id:
-              _eq: X-Hasura-User-Id
-          - role:
-              _eq: teacher
-      limit: 50
-    role: student
-  - permission:
-      columns:
-        - created_at
-        - email
-        - first_name
-        - id
-        - last_name
-        - middle_name
-        - role
-        - school_id
-        - updated_at
-      filter:
-        _or:
-          - id:
-              _eq: X-Hasura-User-Id
-          - role:
-              _in:
-                - student
-                - teacher
-      limit: 50
-    role: teacher
+    limit: 50
+  role: student
+- permission:
+    columns:
+    - created_at
+    - email
+    - first_name
+    - id
+    - last_name
+    - middle_name
+    - role
+    - school_id
+    - updated_at
+    filter:
+      _or:
+      - id:
+          _eq: X-Hasura-User-Id
+      - role:
+          _in:
+          - student
+          - teacher
+    limit: 50
+  role: teacher
 update_permissions:
-  - permission:
-      check: null
-      columns:
-        - first_name
-        - last_name
-        - middle_name
-        - school_id
-      filter:
-        id:
-          _eq: X-Hasura-User-Id
-    role: student
-  - permission:
-      check: null
-      columns:
-        - first_name
-        - last_name
-        - middle_name
-        - school_id
-      filter:
-        id:
-          _eq: X-Hasura-User-Id
-    role: teacher
+- permission:
+    check: null
+    columns:
+    - first_name
+    - last_name
+    - middle_name
+    - school_id
+    filter:
+      id:
+        _eq: X-Hasura-User-Id
+  role: student
+- permission:
+    check: null
+    columns:
+    - first_name
+    - last_name
+    - middle_name
+    - school_id
+    filter:
+      id:
+        _eq: X-Hasura-User-Id
+  role: teacher
 delete_permissions:
-  - permission:
-      filter:
-        id:
-          _eq: X-Hasura-User-Id
-    role: student
-  - permission:
-      filter:
-        id:
-          _eq: X-Hasura-User-Id
-    role: teacher
+- permission:
+    filter:
+      id:
+        _eq: X-Hasura-User-Id
+  role: student
+- permission:
+    filter:
+      id:
+        _eq: X-Hasura-User-Id
+  role: teacher

--- a/db/metadata/databases/default/tables/public_work_summaries.yaml
+++ b/db/metadata/databases/default/tables/public_work_summaries.yaml
@@ -2,37 +2,37 @@ table:
   name: work_summaries
   schema: public
 object_relationships:
-  - name: work_type
-    using:
-      manual_configuration:
-        column_mapping:
-          type: value
-        insertion_order: null
-        remote_table:
-          name: work_type
-          schema: public
+- name: work_type
+  using:
+    manual_configuration:
+      column_mapping:
+        type: value
+      insertion_order: null
+      remote_table:
+        name: work_type
+        schema: public
 select_permissions:
-  - permission:
-      columns:
-        - work_count
-        - creator
-        - name
-        - type
-      filter: {}
-    role: anonymous
-  - permission:
-      columns:
-        - work_count
-        - creator
-        - name
-        - type
-      filter: {}
-    role: student
-  - permission:
-      columns:
-        - name
-        - creator
-        - type
-        - work_count
-      filter: {}
-    role: teacher
+- permission:
+    columns:
+    - work_count
+    - creator
+    - name
+    - type
+    filter: {}
+  role: anonymous
+- permission:
+    columns:
+    - work_count
+    - creator
+    - name
+    - type
+    filter: {}
+  role: student
+- permission:
+    columns:
+    - name
+    - creator
+    - type
+    - work_count
+    filter: {}
+  role: teacher

--- a/db/metadata/databases/default/tables/public_work_summaries.yaml
+++ b/db/metadata/databases/default/tables/public_work_summaries.yaml
@@ -2,40 +2,37 @@ table:
   name: work_summaries
   schema: public
 object_relationships:
-- name: work_type
-  using:
-    manual_configuration:
-      column_mapping:
-        type: value
-      insertion_order: null
-      remote_table:
-        name: work_type
-        schema: public
+  - name: work_type
+    using:
+      manual_configuration:
+        column_mapping:
+          type: value
+        insertion_order: null
+        remote_table:
+          name: work_type
+          schema: public
 select_permissions:
-- permission:
-    columns:
-    - work_count
-    - creator
-    - name
-    - type
-    filter: {}
-    limit: 50
-  role: anonymous
-- permission:
-    columns:
-    - work_count
-    - creator
-    - name
-    - type
-    filter: {}
-    limit: 50
-  role: student
-- permission:
-    columns:
-    - name
-    - creator
-    - type
-    - work_count
-    filter: {}
-    limit: 50
-  role: teacher
+  - permission:
+      columns:
+        - work_count
+        - creator
+        - name
+        - type
+      filter: {}
+    role: anonymous
+  - permission:
+      columns:
+        - work_count
+        - creator
+        - name
+        - type
+      filter: {}
+    role: student
+  - permission:
+      columns:
+        - name
+        - creator
+        - type
+        - work_count
+      filter: {}
+    role: teacher

--- a/db/metadata/databases/default/tables/public_works.yaml
+++ b/db/metadata/databases/default/tables/public_works.yaml
@@ -2,113 +2,113 @@ table:
   name: works
   schema: public
 object_relationships:
-  - name: characterization
-    using:
-      manual_configuration:
-        column_mapping:
-          id: work_id
-        insertion_order: null
-        remote_table:
-          name: characterizations
-          schema: public
-  - name: essay
-    using:
-      manual_configuration:
-        column_mapping:
-          id: work_id
-        insertion_order: null
-        remote_table:
-          name: essays
-          schema: public
-  - name: teacher
-    using:
-      foreign_key_constraint_on: teacher_id
-  - name: users_all
-    using:
-      foreign_key_constraint_on: user_id
-  - name: work_status
-    using:
-      foreign_key_constraint_on: status
+- name: characterization
+  using:
+    manual_configuration:
+      column_mapping:
+        id: work_id
+      insertion_order: null
+      remote_table:
+        name: characterizations
+        schema: public
+- name: essay
+  using:
+    manual_configuration:
+      column_mapping:
+        id: work_id
+      insertion_order: null
+      remote_table:
+        name: essays
+        schema: public
+- name: teacher
+  using:
+    foreign_key_constraint_on: teacher_id
+- name: users_all
+  using:
+    foreign_key_constraint_on: user_id
+- name: work_status
+  using:
+    foreign_key_constraint_on: status
 array_relationships:
-  - name: bookmarks
-    using:
-      foreign_key_constraint_on:
-        column: work_id
-        table:
-          name: bookmarks
-          schema: public
+- name: bookmarks
+  using:
+    foreign_key_constraint_on:
+      column: work_id
+      table:
+        name: bookmarks
+        schema: public
 insert_permissions:
-  - permission:
-      backend_only: true
-      check:
-        user_id:
-          _eq: X-Hasura-User-Id
-      columns:
-        - content
-        - status
-      set:
-        user_id: x-hasura-User-Id
-    role: student
-  - permission:
-      backend_only: true
-      check:
-        user_id:
-          _eq: X-Hasura-User-Id
-      columns:
-        - content
-        - status
-      set:
-        user_id: x-hasura-User-Id
-    role: teacher
+- permission:
+    backend_only: true
+    check:
+      user_id:
+        _eq: X-Hasura-User-Id
+    columns:
+    - content
+    - status
+    set:
+      user_id: x-hasura-User-Id
+  role: student
+- permission:
+    backend_only: true
+    check:
+      user_id:
+        _eq: X-Hasura-User-Id
+    columns:
+    - content
+    - status
+    set:
+      user_id: x-hasura-User-Id
+  role: teacher
 select_permissions:
-  - permission:
-      columns:
-        - content
-        - updated_at
-      filter:
-        status:
+- permission:
+    columns:
+    - content
+    - updated_at
+    filter:
+      status:
+        _eq: approved
+    limit: 50
+  role: anonymous
+- permission:
+    columns:
+    - content
+    - created_at
+    - status
+    - updated_at
+    filter:
+      _or:
+      - status:
           _eq: approved
-      limit: 50
-    role: anonymous
-  - permission:
-      columns:
-        - content
-        - created_at
-        - status
-        - updated_at
-      filter:
-        _or:
+      - user_id:
+          _eq: X-Hasura-User-Id
+    limit: 50
+  role: student
+- permission:
+    columns:
+    - content
+    - created_at
+    - status
+    - updated_at
+    filter:
+      _or:
+      - _or:
+        - status:
+            _in:
+            - pending
+            - approved
+        - _and:
           - status:
-              _eq: approved
-          - user_id:
-              _eq: X-Hasura-User-Id
-      limit: 50
-    role: student
-  - permission:
-      columns:
-        - content
-        - created_at
-        - status
-        - updated_at
-      filter:
-        _or:
-          - _or:
-              - status:
-                  _in:
-                    - pending
-                    - approved
-              - _and:
-                  - status:
-                      _eq: inReview
-                  - teacher_id:
-                      _eq: X-Hasura-User-Id
-          - user_id:
-              _eq: X-Hasura-User-Id
+              _eq: inReview
           - teacher_id:
               _eq: X-Hasura-User-Id
-          - users_all:
-              teacher_student_associations:
-                teacher_id:
-                  _eq: X-Hasura-User-Id
-      limit: 50
-    role: teacher
+      - user_id:
+          _eq: X-Hasura-User-Id
+      - teacher_id:
+          _eq: X-Hasura-User-Id
+      - users_all:
+          teacher_student_associations:
+            teacher_id:
+              _eq: X-Hasura-User-Id
+    limit: 50
+  role: teacher

--- a/db/metadata/databases/default/tables/public_works.yaml
+++ b/db/metadata/databases/default/tables/public_works.yaml
@@ -2,113 +2,113 @@ table:
   name: works
   schema: public
 object_relationships:
-- name: characterization
-  using:
-    manual_configuration:
-      column_mapping:
-        id: work_id
-      insertion_order: null
-      remote_table:
-        name: characterizations
-        schema: public
-- name: essay
-  using:
-    manual_configuration:
-      column_mapping:
-        id: work_id
-      insertion_order: null
-      remote_table:
-        name: essays
-        schema: public
-- name: teacher
-  using:
-    foreign_key_constraint_on: teacher_id
-- name: users_all
-  using:
-    foreign_key_constraint_on: user_id
-- name: work_status
-  using:
-    foreign_key_constraint_on: status
+  - name: characterization
+    using:
+      manual_configuration:
+        column_mapping:
+          id: work_id
+        insertion_order: null
+        remote_table:
+          name: characterizations
+          schema: public
+  - name: essay
+    using:
+      manual_configuration:
+        column_mapping:
+          id: work_id
+        insertion_order: null
+        remote_table:
+          name: essays
+          schema: public
+  - name: teacher
+    using:
+      foreign_key_constraint_on: teacher_id
+  - name: users_all
+    using:
+      foreign_key_constraint_on: user_id
+  - name: work_status
+    using:
+      foreign_key_constraint_on: status
 array_relationships:
-- name: bookmarks
-  using:
-    foreign_key_constraint_on:
-      column: work_id
-      table:
-        name: bookmarks
-        schema: public
+  - name: bookmarks
+    using:
+      foreign_key_constraint_on:
+        column: work_id
+        table:
+          name: bookmarks
+          schema: public
 insert_permissions:
-- permission:
-    backend_only: true
-    check:
-      user_id:
-        _eq: X-Hasura-User-Id
-    columns:
-    - content
-    - status
-    set:
-      user_id: x-hasura-User-Id
-  role: student
-- permission:
-    backend_only: true
-    check:
-      user_id:
-        _eq: X-Hasura-User-Id
-    columns:
-    - content
-    - status
-    set:
-      user_id: x-hasura-User-Id
-  role: teacher
-select_permissions:
-- permission:
-    columns:
-    - content
-    - updated_at
-    filter:
-      status:
-        _eq: approved
-    limit: 10
-  role: anonymous
-- permission:
-    columns:
-    - content
-    - created_at
-    - status
-    - updated_at
-    filter:
-      _or:
-      - status:
-          _eq: approved
-      - user_id:
+  - permission:
+      backend_only: true
+      check:
+        user_id:
           _eq: X-Hasura-User-Id
-    limit: 10
-  role: student
-- permission:
-    columns:
-    - content
-    - created_at
-    - status
-    - updated_at
-    filter:
-      _or:
-      - _or:
-        - status:
-            _in:
-            - pending
-            - approved
-        - _and:
+      columns:
+        - content
+        - status
+      set:
+        user_id: x-hasura-User-Id
+    role: student
+  - permission:
+      backend_only: true
+      check:
+        user_id:
+          _eq: X-Hasura-User-Id
+      columns:
+        - content
+        - status
+      set:
+        user_id: x-hasura-User-Id
+    role: teacher
+select_permissions:
+  - permission:
+      columns:
+        - content
+        - updated_at
+      filter:
+        status:
+          _eq: approved
+      limit: 50
+    role: anonymous
+  - permission:
+      columns:
+        - content
+        - created_at
+        - status
+        - updated_at
+      filter:
+        _or:
           - status:
-              _eq: inReview
+              _eq: approved
+          - user_id:
+              _eq: X-Hasura-User-Id
+      limit: 50
+    role: student
+  - permission:
+      columns:
+        - content
+        - created_at
+        - status
+        - updated_at
+      filter:
+        _or:
+          - _or:
+              - status:
+                  _in:
+                    - pending
+                    - approved
+              - _and:
+                  - status:
+                      _eq: inReview
+                  - teacher_id:
+                      _eq: X-Hasura-User-Id
+          - user_id:
+              _eq: X-Hasura-User-Id
           - teacher_id:
               _eq: X-Hasura-User-Id
-      - user_id:
-          _eq: X-Hasura-User-Id
-      - teacher_id:
-          _eq: X-Hasura-User-Id
-      - users_all:
-          teacher_student_associations:
-            teacher_id:
-              _eq: X-Hasura-User-Id
-    limit: 10
-  role: teacher
+          - users_all:
+              teacher_student_associations:
+                teacher_id:
+                  _eq: X-Hasura-User-Id
+      limit: 50
+    role: teacher

--- a/db/migrations/default/1618496162163_registered_checks/down.sql
+++ b/db/migrations/default/1618496162163_registered_checks/down.sql
@@ -1,0 +1,7 @@
+set search_path to public;
+
+alter table teacher_student_associations drop constraint association_parties_are_registered;
+alter table teacher_requests drop constraint teacher_request_user_is_registered;
+alter table works drop constraint work_user_is_registered;
+
+drop function is_registered_user;

--- a/db/migrations/default/1618496162163_registered_checks/up.sql
+++ b/db/migrations/default/1618496162163_registered_checks/up.sql
@@ -1,0 +1,15 @@
+set search_path to public;
+
+create function is_registered_user(userID int) returns bool stable as $$
+declare updatedAt timestamp;
+begin
+    select updated_at from users_all where id = userID into updatedAt;
+    return updatedAt is not null;
+end;
+$$ language plpgsql;
+
+alter table works add constraint work_user_is_registered check (is_registered_user(user_id));
+
+alter table teacher_requests add constraint teacher_request_user_is_registered check (is_registered_user(user_id));
+
+alter table teacher_student_associations add constraint association_parties_are_registered check (is_registered_user(student_id) and is_registered_user(teacher_id));

--- a/db/migrations/default/1618597107779_bookmark_work_check/down.sql
+++ b/db/migrations/default/1618597107779_bookmark_work_check/down.sql
@@ -1,0 +1,6 @@
+set search_path to public;
+
+alter table bookmarks drop constraint bookmark_registered_user;
+alter table bookmarks drop constraint bookmark_approved_works;
+
+drop function get_work_status;

--- a/db/migrations/default/1618597107779_bookmark_work_check/down.sql
+++ b/db/migrations/default/1618597107779_bookmark_work_check/down.sql
@@ -1,6 +1,5 @@
 set search_path to public;
 
-alter table bookmarks drop constraint bookmark_registered_user;
 alter table bookmarks drop constraint bookmark_approved_works;
 
 drop function get_work_status;

--- a/db/migrations/default/1618597107779_bookmark_work_check/up.sql
+++ b/db/migrations/default/1618597107779_bookmark_work_check/up.sql
@@ -10,5 +10,3 @@ $$ language plpgsql;
 
 alter table bookmarks
     add constraint bookmark_approved_works check (get_work_status(work_id) = 'approved');
-alter table bookmarks
-    add constraint bookmark_registered_user check (is_registered_user(user_id));

--- a/db/migrations/default/1618597107779_bookmark_work_check/up.sql
+++ b/db/migrations/default/1618597107779_bookmark_work_check/up.sql
@@ -1,0 +1,14 @@
+set search_path to public;
+
+create function get_work_status(workID int) returns text stable as $$
+declare workStatus text;
+begin
+    select status from works where id = workID into workStatus;
+    return workStatus;
+end;
+$$ language plpgsql;
+
+alter table bookmarks
+    add constraint bookmark_approved_works check (get_work_status(work_id) = 'approved');
+alter table bookmarks
+    add constraint bookmark_registered_user check (is_registered_user(user_id));

--- a/db/migrations/default/1618597125038_works_random_list_view/down.sql
+++ b/db/migrations/default/1618597125038_works_random_list_view/down.sql
@@ -1,0 +1,5 @@
+set search_path to public;
+
+drop function list_characterizations;
+drop function list_essays;
+drop domain seed;

--- a/db/migrations/default/1618597125038_works_random_list_view/up.sql
+++ b/db/migrations/default/1618597125038_works_random_list_view/up.sql
@@ -1,0 +1,17 @@
+set search_path to public;
+
+create domain seed as float check (value <= 1) check (value >= -1);
+
+create function list_essays(titleID int, seed seed) returns setof essays stable as $$
+begin
+    perform setseed(seed);
+    return query select * from essays where title_id = titleID order by random();
+end;
+$$ language plpgsql;
+
+create function list_characterizations(characterID int, seed seed) returns setof characterizations stable as $$
+begin
+    perform setseed(seed);
+    return query select * from characterizations where character_id = characterID order by random();
+end;
+$$ language plpgsql;

--- a/db/migrations/default/1618600121190_association_has_initiator/down.sql
+++ b/db/migrations/default/1618600121190_association_has_initiator/down.sql
@@ -1,0 +1,3 @@
+set search_path to public;
+
+alter table teacher_student_associations drop constraint teacher_student_association_has_initiator;

--- a/db/migrations/default/1618600121190_association_has_initiator/up.sql
+++ b/db/migrations/default/1618600121190_association_has_initiator/up.sql
@@ -1,0 +1,4 @@
+set search_path to public;
+
+alter table teacher_student_associations
+    add constraint teacher_student_association_has_initiator check (initiator_id = student_id or initiator_id = teacher_id);


### PR DESCRIPTION
A user is registered if they filled in their name and school. This PR prevents at the database level unregistered users from being included in relationships modeled by the tables `works`, `teacher_requests`, and `teacher_student_associations`, where it's required to have this registration data in order to be identified by the other parties of those relations.

The PR also adds a constraint that checks if the initiator of a teacher-student association is part of that association, and creates functions that allow retrieving lists of characterizations and essays for a certain character/title in random order. It also relaxes the strict limit of maximum 10 rows fetched imposed on some tables.